### PR TITLE
Fix a flaky test

### DIFF
--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -96,6 +96,7 @@ class TestApiClient(BaseTestCase):
 
     @mock.patch('requests.session', side_effect=mock.MagicMock)
     def test_authentication_error(self, session_mock):
+        mock.MagicMock.content = PropertyMock(return_value='{"error": {}}')
         mock.MagicMock.ok = PropertyMock(return_value=False)
         mock.MagicMock.status_code = PropertyMock(return_value=401)
         client = TestApiClient.mock_client()


### PR DESCRIPTION
## What is the purpose of the change
This PR is to fix a flaky test `tests/test_api_client.py::TestApiClient::test_authentication_error`, which can fail after running `tests/test_api_client.py::TestApiClient::test_param_required_error`, but passes when it is run in isolation.

## Reproduce the test failure
Run the following command:
```
python -m pytest tests/test_api_client.py::TestApiClient::test_param_required_error tests/test_api_client.py::TestApiClient::test_authentication_error
```

## Expected result
Test `tests/test_api_client.py::TestApiClient::test_authentication_error` should pass when it is run after test `tests/test_api_client.py::TestApiClient::test_param_required_error`.

## Actual result
Test `tests/test_api_client.py::TestApiClient::test_authentication_error` fails:
```
   def _proceed_response(self, response):
        if not response.ok:
>           raise build_api_error(response)
E           coinbase_commerce.error.ParamRequiredError: Request id <MagicMock name='mock.get().headers.get()' id='140023001166560'>: <empty message>

coinbase_commerce/client.py:89: ParamRequiredError

```
## Why the test fails
The error return value of `mock.MagicMock.content` is polluted after `tests/test_api_client.py::TestApiClient::test_param_required_error`.

## Fix
Reset `mock.MagicMock.content`.